### PR TITLE
Fix for interface version 1.0 and especially ReloadUIAddon()

### DIFF
--- a/DevTools.lua
+++ b/DevTools.lua
@@ -1,5 +1,5 @@
 
-DevTools = CreateAddon("DevTools")
+DevTools = EasyUI.CreateAddon("DevTools")
 
 local nViewType = nil
 local szUitexPath = nil

--- a/DevTools.lua
+++ b/DevTools.lua
@@ -421,8 +421,8 @@ function DevTools:LoadEventIDBox(hWin)
 		self:Append("CheckBox", hWin, "CheckBox_" .. v[2], {x = ((k - 1) % 3) * 100 + 30, y = math.floor((k - 1) / 3) * 40 + 60, w = 100, text = v[1]})
 	end
 	self:Append("Text", hWin, "EventIDTexr", {x = 35, y = 10, text = "事件ID："})
-	hBtnCalc = self:Append("Button", hWin, "BtnCalc", {x = 200, y = 10, text = "计算"})
-	hEventIDEdit = self:Append("Edit", hWin, "EventIDEdit", {w = 100, h = 25, x = 90, y = 11, text = "0"})
+	local hBtnCalc = self:Append("Button", hWin, "BtnCalc", {x = 200, y = 10, text = "计算"})
+	local hEventIDEdit = self:Append("Edit", hWin, "EventIDEdit", {w = 100, h = 25, x = 90, y = 11, text = "0"})
 	hBtnCalc.OnClick = function()
 		local tBitTab = {}
 		for i = 1, 22 do

--- a/EasyManager.lua
+++ b/EasyManager.lua
@@ -1,5 +1,5 @@
 
-EasyManager = CreateAddon("EasyManager")
+EasyManager = EasyUI.CreateAddon("EasyManager")
 EasyManager:BindEvent("OnFrameDestroy", "OnDestroy")
 
 EasyManager.tAddonClass = {
@@ -204,7 +204,7 @@ RegisterEvent("LOADING_END", function()
 	local hWnd = Station.Lookup("Normal/Minimap/Wnd_Minimap/Wnd_Over")
 	local btn = hWnd:Lookup("Btn_EasyManager")
 	if not btn then
-		btn = CreateUIButton(hWnd, "Btn_EasyManager", {w = 34, h = 34, x = -5, y = 130, ani = {"ui\\Image\\Button\\SystemButton.UITex", 39, 40, 41, 42}})
+		btn = EasyUI.CreateUIButton(hWnd, "Btn_EasyManager", {w = 34, h = 34, x = -5, y = 130, ani = {"ui\\Image\\Button\\SystemButton.UITex", 39, 40, 41, 42}})
 		btn.OnClick = function()
 			-- When ReloadUIAddon() called, the _G and EasyManager would not be update here
 			this.__reference:OpenPanel()

--- a/EasyManager.lua
+++ b/EasyManager.lua
@@ -203,21 +203,23 @@ end
 RegisterEvent("LOADING_END", function()
 	local hWnd = Station.Lookup("Normal/Minimap/Wnd_Minimap/Wnd_Over")
 	local btn = hWnd:Lookup("Btn_EasyManager")
-	if not btn then
-		btn = EasyUI.CreateUIButton(hWnd, "Btn_EasyManager", {w = 34, h = 34, x = -5, y = 130, ani = {"ui\\Image\\Button\\SystemButton.UITex", 39, 40, 41, 42}})
-		btn.OnClick = function()
+	if btn then
+		btn.__reference = EasyManager
+	else
+		local uiBtn = EasyUI.CreateUIButton(hWnd, "Btn_EasyManager", {w = 34, h = 34, x = -5, y = 130, ani = {"ui\\Image\\Button\\SystemButton.UITex", 39, 40, 41, 42}})
+		uiBtn:GetSelf().__reference = EasyManager
+		uiBtn.OnClick = function()
 			-- When ReloadUIAddon() called, the _G and EasyManager would not be update here
 			this.__reference:OpenPanel()
 		end
-		btn.OnEnter = function()
+		uiBtn.OnEnter = function()
 			local x, y = this:GetAbsPos()
 			local w, h = this:GetSize()
 			local szTip = GetFormatText("插件管理", 163) .. GetFormatText("\n单击这里可以打开插件管理器。", 162)
 			OutputTip(szTip, 400, {x, y, w, h})
 		end
-		btn.OnLeave = function()
+		uiBtn.OnLeave = function()
 			HideTip()
 		end
 	end
-	btn.__reference = EasyManager
 end)

--- a/EasyManager.lua
+++ b/EasyManager.lua
@@ -193,20 +193,21 @@ end
 
 function EasyManager:OpenPanel()
 	local frame = self:Fetch("EasyManager")
-	if frame and frame:IsVisible() then
+	if frame and frame:IsValid() and frame:IsVisible() then
 		frame:Destroy()
 	else
 		frame = self:Init()
 		PlaySound(SOUND.UI_SOUND,g_sound.OpenFrame)
 	end
 end
-
 RegisterEvent("LOADING_END", function()
 	local hWnd = Station.Lookup("Normal/Minimap/Wnd_Minimap/Wnd_Over")
-	if not hWnd:Lookup("Btn_EasyManager") then
-		local btn = CreateUIButton(hWnd, "Btn_EasyManager", {w = 34, h = 34, x = -5, y = 130, ani = {"ui\\Image\\Button\\SystemButton.UITex", 39, 40, 41, 42}})
+	local btn = hWnd:Lookup("Btn_EasyManager")
+	if not btn then
+		btn = CreateUIButton(hWnd, "Btn_EasyManager", {w = 34, h = 34, x = -5, y = 130, ani = {"ui\\Image\\Button\\SystemButton.UITex", 39, 40, 41, 42}})
 		btn.OnClick = function()
-			EasyManager:OpenPanel()
+			-- When ReloadUIAddon() called, the _G and EasyManager would not be update here
+			this.__reference:OpenPanel()
 		end
 		btn.OnEnter = function()
 			local x, y = this:GetAbsPos()
@@ -218,4 +219,5 @@ RegisterEvent("LOADING_END", function()
 			HideTip()
 		end
 	end
+	btn.__reference = EasyManager
 end)

--- a/EasyTestAddon.lua
+++ b/EasyTestAddon.lua
@@ -1,7 +1,7 @@
 
 
 -- ´´½¨²å¼þ
-EasyTestAddon = CreateAddon("EasyTestAddon")
+EasyTestAddon = EasyUI.CreateAddon("EasyTestAddon")
 
 EasyTestAddon:BindEvent("OnFrameDragEnd", "OnDragEnd")
 EasyTestAddon:BindEvent("OnFrameDestroy", "OnDestroy")

--- a/EasyUI.lua
+++ b/EasyUI.lua
@@ -6,6 +6,12 @@
 -- CreatData: 2013.9.24
 ----------------------------------------------
 
+do
+	if EasyUI then
+		return
+	end
+end
+
 ----------------------------------------------
 -- Lua OOP
 ----------------------------------------------
@@ -2443,8 +2449,9 @@ local _API = {
 }
 
 do
+	EasyUI = {}
 	for k, v in pairs(_API) do
-		_G[k] = v
+		EasyUI[k] = v
 	end
 end
 

--- a/EasyUI.lua
+++ b/EasyUI.lua
@@ -83,6 +83,10 @@ function WndBase:ctor(__this)
 	self.__listeners = {self}
 end
 
+function WndBase:IsValid()
+	return self.__this:IsValid()
+end
+
 function WndBase:GetName()
 	return self.__this:GetName()
 end
@@ -773,7 +777,6 @@ end
 
 -- WndRadioBox Object
 local WndRadioBox = class(WndBase)
-local __RadioBoxGroups = {}
 function WndRadioBox:ctor(__parent, __name, __data)
 	assert(__parent ~= nil, "parent can not be null.")
 	__data = __data or {}
@@ -795,8 +798,8 @@ function WndRadioBox:ctor(__parent, __name, __data)
 	--Bind RadioBox Events
 	self.__this.OnCheckBoxCheck = function()
 		if self.__group then
-			for k, v in pairs(__RadioBoxGroups[self.__group]) do
-				if v:GetGroup() == this.__group and v:GetName() ~= this:GetName() then
+			for k, v in pairs(self.__parent.groups[self.__group]) do
+				if v:IsValid() and v:GetGroup() == self.__group and v:GetName() ~= self:GetName() then
 					v:Check(false)
 				end
 			end
@@ -812,10 +815,13 @@ end
 
 function WndRadioBox:SetGroup(__group)
 	if __group then
-		if not __RadioBoxGroups[__group] then
-			__RadioBoxGroups[__group] = {}
+		if not self.__parent.groups then
+			self.__parent.groups = {}
 		end
-		table.insert(__RadioBoxGroups[__group], self)
+		if not self.__parent.groups[__group] then
+			self.__parent.groups[__group] = {}
+		end
+		table.insert(self.__parent.groups[__group], self)
 	end
 	self.__group = __group
 	return self
@@ -874,7 +880,6 @@ end
 
 -- WndUICheckBox Object
 local WndUICheckBox = class(WndBase)
-local __UICheckBoxGroups = {}
 function WndUICheckBox:ctor(__parent, __name, __data)
 	assert(__parent ~= nil, "parent can not be null.")
 	__data = __data or {}
@@ -895,8 +900,8 @@ function WndUICheckBox:ctor(__parent, __name, __data)
 	--Bind UICheckBox Events
 	self.__this.OnCheckBoxCheck = function()
 		if self.__group then
-			for k, v in pairs(__UICheckBoxGroups[self.__group]) do
-				if v:GetGroup() == this.__group and v:GetName() ~= this:GetName() then
+			for k, v in pairs(self.__parent.groups[self.__group]) do
+				if v:IsValid() and v:GetGroup() == self.__group and v:GetName() ~= self:GetName() then
 					v:Check(false)
 				end
 			end
@@ -907,10 +912,13 @@ end
 
 function WndUICheckBox:SetGroup(__group)
 	if __group then
-		if not __UICheckBoxGroups[__group] then
-			__UICheckBoxGroups[__group] = {}
+		if not self.__parent.groups then
+			self.__parent.groups = {}
 		end
-		table.insert(__UICheckBoxGroups[__group], self)
+		if not self.__parent.groups[__group] then
+			self.__parent.groups[__group] = {}
+		end
+		table.insert(self.__parent.groups[__group], self)
 	end
 	self.__group = __group
 	return self
@@ -1124,6 +1132,7 @@ function WndScroll:GetHandle()
 end
 
 function WndScroll:AddItem(__name)
+	assert(false, "do not use this api")
 	local __item = ScrollItems.new(self:GetHandle(), "Handle_Item", "Item_" .. __name)
 	__item:Show()
 	local __cover = __item:GetSelf():Lookup("Image_Cover")
@@ -2306,7 +2315,7 @@ end
 -- Addon Class
 local CreateAddon = class()
 local Addon_List = {}
-function CreateAddon_new(__name)
+local function CreateAddon_new(__name)
 	if not Addon_List[__name] then
 		Addon_List[__name] = CreateAddon.new(__name)
 	end

--- a/EasyUITestCase.lua
+++ b/EasyUITestCase.lua
@@ -168,7 +168,7 @@ local tConfigDev = {
 EasyManager:RegisterPanel(tConfigDev)
 
 do
-	for i = 1, 10 do
+	for i = 1, 3 do
 		local cfg = {
 			szName = "TestA" .. i,
 			szTitle = "≤‚ ‘" .. i,

--- a/TestCase.lua
+++ b/TestCase.lua
@@ -1,5 +1,5 @@
 
-EasyTest  =  CreateAddon("EasyTest")
+EasyTest  =  EasyUI.CreateAddon("EasyTest")
 
 function GetLuaFrameInfo()
 	local tLayer =

--- a/info.ini
+++ b/info.ini
@@ -1,10 +1,11 @@
 [EasyUI]
 name=EasyUI
 desc=EasyUI½çÃæ¿â by crazy
-version=0.9
+version=1.0
 default=1
-lua_0=Interface\EasyUI\EasyUI.lua
-lua_1=Interface\EasyUI\EasyManager.lua
-lua_2=Interface\EasyUI\EasyUITestCase.lua
-lua_3=Interface\EasyUI\DevTools.lua
-
+lua_0=EasyUI.lua
+lua_1=EasyManager.lua
+;lua_2=EasyUITestCase.lua
+;lua_3=EasyTestAddon.lua
+;lua_4=DevTools.lua
+;lua_5=TestCase.lua


### PR DESCRIPTION
1. fix some variable that should be local like `hBtnCalc` and `hEventIDEdit` in DevTools.lua
2. add IsValid method to class WndBase, and check it before destroy
3. add `btn.__reference = EasyManager` trick to update EasyManager after `ReloadUIAddon()`
4. remove `__RadioBoxGroups` and `__UICheckBoxGroups`, instead, using `self.__parent.groups`, which avoid some operation on invalid CheckBox, and prevent same name groups between frame (we believe CheckBox in different `WndBase` should have different groups)
